### PR TITLE
Add sections on CDDL and wrapping

### DIFF
--- a/draft-ietf-cbor-serialization.md
+++ b/draft-ietf-cbor-serialization.md
@@ -299,24 +299,23 @@ But note that determinstic is never a substitue for general serialization where 
 
 Four new control operators are defined for use in CDDL {{-cddl}}.
 
-| Name    | Purpose                                         |
-| .ord    | Use ordinary serialization for a data item      |
-| .ordseq | Use ordinary serialization for a CBOR sequence  |
-| .det    | Use deterministic serialization for a data item |
-| .detseq | Use for a CBOR sequnce                          |
+| Name    | Purpose                                             |
+| .ord    | Use ordinary serialization for a data item          |
+| .ordseq | Use ordinary serialization for a CBOR sequence      |
+| .det    | Use deterministic serialization for a data item     |
+| .detseq | Use deterministic serialization for a CBOR sequence |
 
-These operators have the same semantics as .cbor and .cborseq operator (See {{Section 3.8.4 of -cddl}}) with the additional requirement for ordinary or deterministic serialization.
+These operators have the same semantics as the .cbor and .cborseq operators (See {{Section 3.8.4 of -cddl}}) with the additional requirement for ordinary or deterministic serialization.
+These specify that what is in the “controller” (the right side of the operator) be serialized as indicated.
 
-For example, a byte string containing embedded CBOR that is to be deterministically encoded can described in CDDL as:
+For example, a byte string containing embedded CBOR that must be deterministically encoded can be described in CDDL as:
 
 ~~~
 leaf = #6.24(bytes .det any)
 ~~~
 
-These control operators specify that everything in the “controller” (the right side of the operator) be serialized as indicated.
-This requirement applies recursively through nested arrays and maps.
-This does NOT apply recursively through the .cbor or .cborseq, nor does it apply to the content of any byte string or other data item that happens to contain encoded CBOR.
-Every instance of embedded CBOR that requires constrained serialization must have that constraint specified explicitly.
+The scope of these operators applies recursively through nested arrays and maps, but does not extend into byte strings or other data items that happen to contain encoded CBOR.
+Every instance of embedded CBOR that requires constrained serialization must specify that constraint explicitly.
 See also {{ByteStringWrapping}}.
 
 
@@ -532,50 +531,54 @@ The advantage of avoiding NaN in CBOR protocols is that they can more easily be 
 
 # CBOR Byte String Wrapping {#ByteStringWrapping}
 
-This appendix gives some non-normative discussion of byte-string wrapping of CBOR.
-It applies primarily to tag 24 and the CDDL .cbor and .cborseq control operators, but also to the serialization-specifying control operators described in {CDDL-Operators}
+This appendix provides non-normative guidance on byte-string wrapping of CBOR.
+It applies primarily to tag 24 and the CDDL .cbor and .cborseq control operators, but also to the serialization-specifying control operators described in {{CDDL-Operators}}.
 
 ## Purpose
 
 Error isolation:
-If the wrapped CBOR contains encoding errors, these do not cause decoding of the enclosing CBOR to fail.
-(CBOR decoding generally halts at the first error and lacks internal length redundancy mechanisms like those in ASN.1/DER.)
 
-CBOR library implementation of signing and hashing:
-When the wrapped CBOR must be signed or hashed, its raw encoded form must be available for input to the signing or hashing function.
-Most CBOR libraries cannot extract the original encoded bytes of substructures, but bstr wrapping provides direct access to the exact bytes being signed or hashed.
+: Wrapping CBOR in a byte string prevents encoding errors in the wrapped data from causing the enclosing CBOR to fail during decoding.
+(CBOR decoding generally halts at the first error and lacks internal length redundancy found in formats like ASN.1/DER.)
+
+CBOR library support for signing and hashing:
+
+: When wrapped CBOR needs to be signed or hashed, its original encoded bytes must be available.
+Most CBOR libraries cannot directly extract the raw bytes of substructures, but byte-string wrapping provides direct access to the exact bytes for signing or hashing.
 
 Protocol embedding:
-Byte-string wrapping is generally useful when messages from one CBOR-based protocol are embedded within another distinct CBOR protocol.
+
+: Byte-string wrapping is generally useful when messages from one CBOR-based protocol need to be embedded within another CBOR protocol.
 
 Special map keys:
-Some CBOR libraries only support simple, non-aggregate map keys like integers and strings.
-To use other data types like arrays and maps as map keys with these libraries, they can be byte-string wrapped.
+
+: Some CBOR libraries only support simple, non-aggregate map keys (e.g., integers or strings).
+To use complex data types like arrays and maps as map keys, they can be wrapped in a byte string.
 
 ## Wrapping Recommendations
 
-The serialization requirements of the wrapping CBOR may differ from those of the wrapped CBOR.
-CBOR itself imposes no universal rule dictating that they must match; this is determined by the design of the wrapping protocol.
+The serialization requirements for the wrapping CBOR may differ from those for the wrapped CBOR.
+CBOR itself imposes no universal rule that they must match; this is determined by the design of the wrapping protocol.
 
 The wrapping protocol should not impose serialization requirements on the wrapped message.
 The two should be treated as independent entities.
 This approach avoids potential conflicts between serialization rules.
 
 For example, assume protocol XYZ wraps protocol ABC.
-If ABC requires Canonical CBOR as specified in {{Section 3.9 of RFC7049}} (e.g., {{CTAP2}} from WebAuthn) while XYZ requires Deterministic Serialization, {{DeterministicSerialization}}, a conflict would arise.
+If protocol ABC requires Canonical CBOR as specified in {{Section 3.9 of RFC7049}} (e.g., {{CTAP2}} from WebAuthn) while protocol XYZ requires deterministic serialization, {{DeterministicSerialization}}, a conflict would arise.
 
-Note that most CBOR data to be signed or hashed does not need to follow any particular serialization rules.
+Most CBOR data to be signed or hashed does not require a specific serialization.
 CBOR, being a modern, fully specified, binary protocol, does not need canonicalization, wrapping, or armoring like other data representation formats such as JSON.
 See the discussion in {{WhenDeterministic}}.
 
-## Decoder Library Implementation Suggestion
+## CBOR Library Implementation Suggestion
 
-A straightforward implementation strategy is to instantiate a second CBOR decoder for the wrapped message.
-However, this can be suboptimal in environments with limited memory, as it requires both a duplicate copy of the wrapped data and an additional decoder instance.
+A straightforward implementation strategy is to instantiate a second CBOR encoder or decoder for the wrapped message.
+However, this may be suboptimal in memory-constrained environments, as it may require both a duplicate copy of the wrapped data and an additional encoder/decoder instance.
 
-A more efficient approach is for the CBOR library to treat the wrapped CBOR similarly to a container, as it might for an array or map.
-Many CBOR implementations already handle arrays and maps as containers without requiring a separate decoder.
-In the same way, a wrapped bstr can be treated as a container that always contains exactly one item—the embedded CBOR message.
+A more efficient approach can be for the CBOR library to treat the wrapped CBOR like a container (similar to arrays or maps).
+Many CBOR implementations already handle arrays and maps as containers without requiring a separate instance.
+Similarly, a byte-string wrapping encoded CBOR can be treated as a container that always contains exactly one item.
 
 
 # Examples and Test Vectors


### PR DESCRIPTION
This adds CDDL operators to specify serialization.

It also adds an appendix on byte string wrapping. 

It is intended to address comments initiated by Ken Takayama on the mailing list on the extent of influence of a serialization requirement.