### PR TITLE
How to properly indicate big numbers in CDDL

### DIFF
--- a/bn.cddl
+++ b/bn.cddl
@@ -1,0 +1,13 @@
+; big number byte strings are of unlimited size, but that 
+; can't be expressed in CDDL, so a limit of 1,000
+bnmax = 1000
+bnbstr = bstr .size (8..bnmax)
+
+pplus-tag2bstr = #6.2(bnbstr)
+pplus-biguint  = #0 / pplus-tag2bstr
+
+pplus-tag3bstr = #6.3(bnbstr)
+pplus-bignint  = #1 / pplus-tag3bstr
+
+pplus-bigint = pplus-biguint / pplus-bignint
+

--- a/draft-ietf-cbor-serialization.md
+++ b/draft-ietf-cbor-serialization.md
@@ -392,6 +392,7 @@ This section defines a serialization named "preferred-plus serialization."
    * An empty byte string MUST be accepted and treated as the value zero.
 
 See also {{BigNumbersDataModel}} and {{BigNumberStrategies}} for further background on big numbers.
+See {{BigNumbersCDDL}} for specification in CDDL.
 
 
 ## When to use preferred-plus serialization
@@ -878,6 +879,14 @@ Rather, it records the commonly accepted interpretation of that text and its imp
 
 This document does create a new rule for future tag definitions.
 See {{TagDataModelRule}}.
+
+
+# Big Numbers in CDDL {#BigNumbersCDDL}
+
+The types bigint and biguint in the CDDL Standard Prelude ({{Appendix D of -cddl}}) do NOT describe the big numbers described in this document or in {{Section 3.4.3 of -cbor}}, not even for general serialization.
+The types integer and unsigned can be used, but note that they do not fully express the rules that govern the choice between major types 0 and 1 and the big number tags.
+CDDL-described protocols SHOULD use integer and unsigned and in prose state that these values correspond to either {{PreferredPlusSerialization}} of this document or {{Section 3.4.3 of -cbor}}.
+{{BigNumbersDataModel}} explains the reasons for this.
 
 
 # Big Number Implementation Strategies {#BigNumberStrategies}

--- a/draft-ietf-cbor-serialization.md
+++ b/draft-ietf-cbor-serialization.md
@@ -881,12 +881,18 @@ This document does create a new rule for future tag definitions.
 See {{TagDataModelRule}}.
 
 
-# Big Numbers in CDDL {#BigNumbersCDDL}
+# CDDL for Big Numbers {#BigNumbersCDDL}
 
 The types bigint and biguint in the CDDL Standard Prelude ({{Appendix D of -cddl}}) do NOT describe the big numbers described in this document or in {{Section 3.4.3 of -cbor}}, not even for general serialization.
 The types integer and unsigned can be used, but note that they do not fully express the rules that govern the choice between major types 0 and 1 and the big number tags.
 CDDL-described protocols SHOULD use integer and unsigned and in prose state that these values correspond to either {{PreferredPlusSerialization}} of this document or {{Section 3.4.3 of -cbor}}.
 {{BigNumbersDataModel}} explains the reasons for this.
+
+The following CDDL can be used:
+
+~~~~
+{::include bn.cddl}
+~~~~
 
 
 # Big Number Implementation Strategies {#BigNumberStrategies}


### PR DESCRIPTION
The CDDL Standard Prelude bigint and biguint are NOT it